### PR TITLE
Adding `Enum.precedes?/3` and `Enum.follows?/3`

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1297,6 +1297,19 @@ defmodule Enum do
   end
 
   @doc """
+  Checks if `following` ever occurs after `preceding` within `enumerable`.
+
+  ## Examples
+
+      iex> Enum.follows?([1,2,3], 3, 1)
+      true
+
+  """
+  @spec follows?(t, any, any) :: boolean
+  def follows?(enumerable, following, preceding),
+    do: enumerable |> :lists.reverse() |> precedes?(following, preceding)
+
+  @doc """
   Returns a map with keys as unique elements of `enumerable` and values
   as the count of every element.
 
@@ -2295,6 +2308,34 @@ defmodule Enum do
   @deprecated "Use Enum.split_with/2 instead"
   def partition(enumerable, fun) do
     split_with(enumerable, fun)
+  end
+
+  @doc """
+  Checks if `preceding` ever occurs before `following` within `enumerable`.
+
+  ## Examples
+
+      iex> Enum.precedes?([1,2,3], 1, 3)
+      true
+
+  """
+  @spec precedes?(t, any, any) :: boolean
+  def precedes?(enumerable, preceding, following) do
+    reduce_while(enumerable, :seen_neither, fn
+      entry, :seen_neither ->
+        if entry == preceding do
+          {:cont, :seen_preceding}
+        else
+          {:cont, :seen_neither}
+        end
+
+      entry, :seen_preceding ->
+        if entry == following do
+          {:halt, true}
+        else
+          {:cont, :seen_preceding}
+        end
+    end) == true
   end
 
   @doc """

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -720,6 +720,7 @@ defmodule EnumTest do
   end
 
   test "precedes?/3" do
+    assert Enum.precedes?([:a, :b, :c], :a, :c) == true
     assert Enum.precedes?([1, 2, 3], 2, 3) == true
     assert Enum.precedes?([{6}, {5}, {4}, {5}, {6}], {4}, {5}) == true
     assert Enum.precedes?([1, 2, 3], 3, 2) == false

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -372,6 +372,14 @@ defmodule EnumTest do
     assert Enum.flat_map_reduce([1, 2, 3], 0, &{[&1, &2], &1 + &2}) == {[1, 0, 2, 1, 3, 3], 6}
   end
 
+  test "follows?/3" do
+    assert Enum.follows?([:a, :b, :c], :c, :a) == true
+    assert Enum.follows?([1, 2, 3], 2, 1) == true
+    assert Enum.follows?([{4}, {5}, {6}, {5}, {4}], {4}, {6}) == true
+    assert Enum.follows?([1, 2, 3], 1, 2) == false
+    assert Enum.follows?(["d", "e", "f"], "e", "e") == false
+  end
+
   test "frequencies/1" do
     assert Enum.frequencies([]) == %{}
     assert Enum.frequencies(~w{a c a a c b}) == %{"a" => 3, "b" => 1, "c" => 2}
@@ -709,6 +717,13 @@ defmodule EnumTest do
     assert_runs_enumeration_only_once(
       &Enum.min_max_by(&1, fn x -> x end, fn a, b -> a > b end, fn -> nil end)
     )
+  end
+
+  test "precedes?/3" do
+    assert Enum.precedes?([1, 2, 3], 2, 3) == true
+    assert Enum.precedes?([{6}, {5}, {4}, {5}, {6}], {4}, {5}) == true
+    assert Enum.precedes?([1, 2, 3], 3, 2) == false
+    assert Enum.precedes?(["d", "e", "f"], "e", "e") == false
   end
 
   test "split_with/2" do


### PR DESCRIPTION
This would be helpful for very lightweight state machine-type validation:

```elixir
iex(1)> career_path = [:intern, :junior, :senior, :staff]
[:intern, :junior, :senior, :staff]
iex(2)> Enum.precedes?(career_path, :intern, :junior)    
true
iex(3)> Enum.precedes?(career_path, :junior, :senior)
true
iex(5)> Enum.follows?(career_path, :doctor, :senior) 
false
iex(6)> Enum.follows?(career_path, :staff, :senior) 
true
```